### PR TITLE
Expose Heroku Router errors as a Prometheus metric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 
-ARG VECTOR_RELEASE=0.13.1
-ARG VECTOR_SHA256=a22054398c06538541764754f0f547e2d841b01067e8ee3515f78c706cf5ca55
+ARG VECTOR_RELEASE=0.26.0
+ARG VECTOR_SHA256=82c501f130327c1a698daeb55edfaad21077d99417a95e81c7796ba2eb73cf92
 
 # Install system dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -13,7 +13,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     && rm -rf /var/lib/apt/lists/*
 
 # Install Vector
-RUN curl -Lo /tmp/vector.tar.gz https://github.com/timberio/vector/releases/download/v${VECTOR_RELEASE}/vector-${VECTOR_RELEASE}-x86_64-unknown-linux-gnu.tar.gz && \
+RUN curl -Lo /tmp/vector.tar.gz https://github.com/vectordotdev/vector/releases/download/v${VECTOR_RELEASE}/vector-${VECTOR_RELEASE}-x86_64-unknown-linux-gnu.tar.gz && \
     echo "${VECTOR_SHA256}  /tmp/vector.tar.gz" | sha256sum -c && \
     tar xf /tmp/vector.tar.gz -C /usr/local/bin --strip-components 3 ./vector-x86_64-unknown-linux-gnu/bin/vector && \
     mkdir /var/lib/vector && \

--- a/simulate-heroku.py
+++ b/simulate-heroku.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# This script sends the output of `heroku logs --tail --app crates-io` to
+# vector.dev, taking care of properly formatting it the way Heroku Logplex
+# would send it.
+#
+# To run it off live data, run:
+#
+#    heroku logs --tail --app crates-io | ./simulate-heroku.py DRAIN_URL
+#
+# To capture a sample of logs and then replay it later run:
+#
+#    heroku logs --tail --app crates-io > cached-logs
+#    cat cached-logs | ./simulate-heroku.py DRAIN_URL
+#
+# Take care of replacing the DRAIN_URL with the URL of your drain. For local
+# execution using the instructions in the README, the DRAIN_URL will be:
+#
+#    http://drain:${DRAIN_PASSWORD}@localhost/drain?app_name=crates-io
+#
+
+import re
+import requests
+import sys
+import uuid
+
+# Regex matching the output of `heroku logs --tail --app crates-io`.
+HEROKU_CLI_RE = re.compile(
+    r"^(?P<time>[^ ]+) (?P<app>[^\[]+)\[(?P<proc>[^\]]+)\]: (?P<message>.*)$"
+)
+
+# Randomly generated but hardcoded drain token for this script.
+DRAIN_TOKEN = "d.25c16be4-2836-4b8f-8b24-4d62def8116c"
+
+# Limit how much data we send to nginx at a time.
+MAX_REQUEST_SIZE = 512 * 1024  # 512 Kb
+
+
+def messages_from_stdin():
+    """Parse the messages from stdin and format them correctly"""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        matches = HEROKU_CLI_RE.search(line)
+        if matches is None:
+            print(f"warn: skipping invalid line: {line}", file=sys.stderr)
+            continue
+
+        # https://stackoverflow.com/a/25247628
+        message = f"<14>1 {matches['time']} host {matches['app']} {matches['proc']} - {matches['message']}"
+        yield str(len(message)) + " " + message
+
+
+def send_messages(drain, messages):
+    resp = requests.post(
+        drain,
+        headers={
+            "Logplex-Msg-Count": str(len(messages)),
+            "Logplex-Frame-Id": str(uuid.uuid4()),
+            "Logplex-Drain-Token": DRAIN_TOKEN,
+            "User-Agent": "debug script",
+            "Content-Type": "application/logplex-1",
+        },
+        data="\n".join(messages),
+    )
+    resp.raise_for_status()
+
+
+def send_all_messages(drain):
+    batch = []
+    for message in messages_from_stdin():
+        batch.append(message)
+        if sum(len(m) for m in batch) > MAX_REQUEST_SIZE:
+            send_messages(drain, batch)
+            batch.clear()
+    # Also send remaining messages
+    if batch:
+        send_messages(drain, batch)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <drain-url>", file=sys.stderr)
+        exit(1)
+
+    send_all_messages(sys.argv[1])

--- a/src/vector.toml
+++ b/src/vector.toml
@@ -18,7 +18,7 @@ query_parameters = ["app_name"]
 # Publish all the collected metrics as a Prometheus exporter.
 [sinks.prometheus]
 type = "prometheus_exporter"
-inputs = ["self", "heroku-postgres", "ingested-metrics"]
+inputs = ["self", "heroku-postgres", "heroku-router-errors", "ingested-metrics"]
 address = "0.0.0.0:8002"
 # Long flush period needed due to Heroku Postgres's log frequency:
 flush_period_secs = 600
@@ -113,3 +113,48 @@ function (event, emit)
     end
 end
 '''
+
+##############################
+#   Heroku Router metrics    #
+##############################
+
+# The Heroku load balancer ("Router") does not emit metrics, but instead logs a
+# line for every request or error, and it's our job to conver them to metrics.
+#
+# The `heroku-router-filter` -> `heroku-router-parse` transforms take care of
+# decoding Heroku Router log messages, and then we use separate transforms for
+# each metric we want to extract out of the logs.
+
+[transforms.heroku-router-filter]
+type = "filter"
+inputs = ["heroku"]
+condition = '.proc_id == "router"'
+
+[transforms.heroku-router-parse]
+type = "remap"
+inputs = ["heroku-router-filter"]
+# Merge into the log message data (".") the parsed key-value message.
+source = '. |= parse_key_value!(.message)'
+
+# Log lines with at=error represent one of the Heroku error codes, listed here:
+#
+#    https://devcenter.heroku.com/articles/error-codes
+#
+# We want to alert when they happen, so we generate metrics counting how many
+# times they happen.
+
+[transforms.heroku-router-errors-filter]
+type = "filter"
+inputs = ["heroku-router-parse"]
+condition = '.at == "error"'
+
+[transforms.heroku-router-errors]
+type = "log_to_metric"
+inputs = ["heroku-router-errors-filter"]
+[[transforms.heroku-router-errors.metrics]]
+type = "counter"
+name = "errors"
+field = "code" # Not sure why this is needed...
+namespace = "heroku_router"
+tags.code = "{{code}}"
+tags.dyno = "{{dyno}}"


### PR DESCRIPTION
This PR changes our vector.dev configuration to expose a counter of the Heroku Router errors:

```
heroku_router_errors{code="H13",dyno="web.4"} 2
heroku_router_errors{code="H13",dyno="web.3"} 1
```

This PR also updates vector.dev to 0.26.0, and adds a new `simulate-heroku.py` to ingest the output of `heroku logs --tail --app crates-io` into vector.dev with the same format and protocol Heroku uses.

Supersedes #4. Compared to that PR, the code in this PR has been tested with the new script, and uses the `filter`/`remap`/`log_to_metric` transforms rather than Lua code. Those transforms provide type checking and better error messages than Lua.