### PR TITLE
Improve labels for the `heroku_router_errors` metric

### DIFF
--- a/src/vector.toml
+++ b/src/vector.toml
@@ -158,4 +158,4 @@ field = "code" # Not sure why this is needed...
 namespace = "heroku_router"
 tags.code = "{{code}}"
 tags.app = "{{app_name}}"
-tags.dyno = "{{dyno}}"
+tags.process = "{{dyno}}"

--- a/src/vector.toml
+++ b/src/vector.toml
@@ -157,4 +157,5 @@ name = "errors"
 field = "code" # Not sure why this is needed...
 namespace = "heroku_router"
 tags.code = "{{code}}"
+tags.app = "{{app_name}}"
 tags.dyno = "{{dyno}}"


### PR DESCRIPTION
This PR adds the `app` label to the `heroku_router_errors` metric (to distinguish between `crates-io` and `staging-crates-io`), and renames the `dyno` metric to `process` for consistency with the other metrics.